### PR TITLE
feat: 카드 전송 메뉴 UI 개선 및 비로그인 사용자 대응 기능 추가 #11

### DIFF
--- a/public/css/index.css
+++ b/public/css/index.css
@@ -555,6 +555,65 @@ DIV {
     font-weight: bold;
 }
 
+.menu-intro {
+  font-size: 30px;
+  color: #555;
+  font-weight: 700;
+  letter-spacing: 5px;
+  margin-top: 50px;
+  text-align: center;
+}
+
+.card-representative {
+  text-align: center;
+  margin-top: 40px;
+  width: 100%;
+}
+
+.card-representative img {
+  display: inline-block;
+  width: 40%;
+  height: auto;
+  border-radius: 10px;
+}
+
+.card-menu {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: flex-start;
+  gap: 30px;
+  margin-top: 30px;
+  flex-wrap: wrap;
+  padding-bottom: 0;
+}
+
+.card-option {
+  text-align: center;
+  background-color: #fffdf8;
+  padding: 10px;
+  border-radius: 15px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+  width: 150px;
+  transition: transform 0.2s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 70px;
+}
+
+.card-option:hover {
+  transform: scale(1.05);
+  background-color: #f5f5f5;
+}
+
+.card-option a {
+  font-size: 1.1em;
+  color: #333;
+  font-weight: bold;
+  text-decoration: none;
+}
+
 .cardtable {
     background-color: #f3f3f398;
     z-index: 8;

--- a/src/routes/authRouter.js
+++ b/src/routes/authRouter.js
@@ -83,4 +83,12 @@ router.get('/kakao/callback', async (req, res) => {
     }
 });
 
+// 로그아웃
+router.post('/logout', (req, res) => {
+  req.session.destroy(() => {
+    res.clearCookie('connect.sid');
+    res.redirect('/auth/kakao');
+  });
+});
+
 module.exports = router;

--- a/views/card/menu.ejs
+++ b/views/card/menu.ejs
@@ -1,7 +1,17 @@
 <div class="position2 box3">
-    <div>
-        <a href="/card/new">카드 작성</a>
-        <a href="/card/sentList">보낸 카드 목록</a>
-        <a href="/card/receivedList">받은 카드 목록</a>
+    <p class="menu-intro">마음을 담아 카드를 보내보세요!</p>
+    <div class="card-representative">
+        <img src="/image/card.png" />
+    </div>
+    <div class="card-menu">
+        <div class="card-option">
+            <a href="/card/new">✍️ 카드 작성</a>
+        </div>
+        <div class="card-option">
+            <a href="/card/receivedList">📥 받은 카드</a>
+        </div>
+        <div class="card-option">
+            <a href="/card/sentList">📤 보낸 카드</a>
+        </div>
     </div>
 </div>

--- a/views/card/new.ejs
+++ b/views/card/new.ejs
@@ -1,20 +1,40 @@
 <div class="position2 box3">
-    <div class="card_background">
-        <img src="image\christmascard_1.png" width="100%">
-    </div>
-    <div class="wirte_card">
-        <form method="post" action="/card">
+    <form method="post" action="/card">
+        <div class="card_background">
+            <label><input type="radio" name="card_type" value="1" hidden><img src="/image/christmascard_1.png" width="20%"></label>
+            <label><input type="radio" name="card_type" value="2" hidden><img src="/image/christmascard_2.png" width="20%"></label>
+            <label><input type="radio" name="card_type" value="3" hidden><img src="/image/christmascard_3.png" width="20%"></label>
+            <label><input type="radio" name="card_type" value="4" hidden><img src="/image/christmascard_4.png" width="20%"></label>
+        </div>
+        <div class="wirte_card">
             <div class="card_title">
                 <label>TO</label>
                 <input type="text" name="to_name" placeholder="받는 사람을 입력하세요" required />
             </div>
             <input type="hidden" name="from_name" value="<%= user?.nickname %>" />
+            <input type="hidden" name="selected_card_type" id="selected_card_type" />
             <div class="card_text">
                 <textarea name="content" placeholder="카드를 작성해보세요 !"></textarea>
             </div>
             <div class="send_card_button">
                 <input type="submit" value="보내기" />
             </div>
-        </form>
-    </div>
+        </div>
+    </form>
 </div>
+<script>
+  const cardRadios = document.querySelectorAll('input[name="card_type"]');
+  const hiddenField = document.getElementById('selected_card_type');
+
+  cardRadios.forEach((radio, index) => {
+    radio.addEventListener('change', () => {
+      hiddenField.value = radio.value;
+    });
+
+    // Optional: allow image click to trigger radio
+    radio.nextElementSibling.addEventListener('click', () => {
+      radio.checked = true;
+      hiddenField.value = radio.value;
+    });
+  });
+</script>

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -1,14 +1,14 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <meta charset="utf-8" />
-  <title> text me </title>
-  <link rel="stylesheet" href="/css/index.css" />
-  <script src="/js/calendar.js"></script>
+    <meta charset="utf-8" />
+    <title> text me </title>
+    <link rel="stylesheet" href="/css/index.css" />
+    <script src="/js/calendar.js"></script>
 </head>
 <body onload="build()">
-  <%- include('partials/header') %>
-  <%- body %>
-  <%- include('partials/footer') %>
+    <%- include('partials/header') %>
+    <%- body %>
+    <%- include('partials/footer') %>
 </body>
 </html>


### PR DESCRIPTION
### 주요 변경사항

#### 카드 전송 메뉴 UI 리디자인 및 기능 분리
- 카드 메뉴 페이지 상단에 대표 이미지 및 안내 문구 추가
- 카드 작성, 받은 카드, 보낸 카드 기능을 세 개의 버튼으로 분리
- 버튼 정렬 구조 및 간격 조정, 이미지와 버튼의 수직 배치로 시각적 정돈
- 안내 문구에 letter-spacing 적용하여 가독성 향상

#### 비로그인 사용자 카드 전송 대응 및 로그아웃 기능 추가
- 로그인되지 않은 사용자가 카드 전송 시 발생하던 오류 방지
- header에 카카오 로그아웃 및 세션 삭제 기능 구현
- 로그아웃 시 홈페이지(`/`)로 안전하게 리다이렉트 처리

---

### 향후 개선 예정 @mimmimkim 

- `/card/new`, `/wish` 등 인증이 필요한 경로 접근 시 인증 미들웨어를 통해 자동 redirect 또는 안내 메시지 제공
- 사용자 경험(UX)을 고려한 "로그인이 필요한 서비스입니다" 안내 추가 예정